### PR TITLE
Update default flag URL to European Union flag image

### DIFF
--- a/scripts/CurrencyService.mjs
+++ b/scripts/CurrencyService.mjs
@@ -53,7 +53,7 @@ class CurrencyService {
                     : null;
                 return {
                     ...currency,
-                    flag: flagInfo ? flagInfo.flag : 'default-flag-url' // Provide a default flag URL or null
+                    flag: flagInfo?.flag ?? 'https://files.softicons.com/download/internet-cons/flag-icons-by-custom-icon-design/png/32/European-Union-Flag.png'
                 };
             });
 
@@ -112,7 +112,6 @@ class CurrencyService {
                 });
             }
 
-            // Save to local storage if not today's date
             HistoryTracker.saveExchangeRate(currency, date, data);
 
             return data;


### PR DESCRIPTION
Change the default flag URL in currency data retrieval to a specific European Union flag image.